### PR TITLE
Remove usage of std::cerr

### DIFF
--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -1,4 +1,5 @@
 #include "../include/cxx.h"
+#include <cstdio>
 #include <cstring>
 #include <iostream>
 #include <memory>
@@ -76,8 +77,8 @@ inline namespace cxxbridge1 {
 template <typename Exception>
 void panic [[noreturn]] (const char *msg) {
 #if defined(RUST_CXX_NO_EXCEPTIONS)
-  std::cerr << "Error: " << msg << ". Aborting." << std::endl;
-  std::terminate();
+  std::fprintf(stderr, "Error: %s. Aborting.\n", msg);
+  std::abort();
 #else
   throw Exception(msg);
 #endif


### PR DESCRIPTION
The usage of std::cerr significantly increases binary size. However, many people disable exceptions for binary size. Also, std::terminate also uses std::cerr to print an abort message and then abort. Here we manually print the abort message and thus use std::abort instead.

Fix #1239